### PR TITLE
Travis-CIのアイコンを追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: c
-script: sudo apt install clang libpcre3-dev -y & ./configure --prefix=$HOME --with-optimize & make && sudo make install && make test
+script: sudo apt install clang libpcre3-dev -y && sudo ./configure --with-optimize && make && sudo make install && make test
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: c
-script: sudo apt install clang libpcre3-dev -y && sudo ./configure --with-optimize && make && sudo make install && make test
+script: sudo apt install clang libpcre3-dev ctags -y && sudo ./configure --with-optimize && make && sudo make install && make test
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: c
-script: make && sudo make install && make test
+script: sudo apt install clang libpcre3-dev -y & make && sudo make install && make test
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: c
+script: make && sudo make install && make test
+sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: c
-script: sudo apt install clang libpcre3-dev -y & make && sudo make install && make test
+script: sudo apt install clang libpcre3-dev -y & ./configure --with-optimize & make && sudo make install && make test
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: c
-script: sudo apt install clang libpcre3-dev -y & ./configure --with-optimize & make && sudo make install && make test
+script: sudo apt install clang libpcre3-dev -y & ./configure --prefix=$HOME --with-optimize & make && sudo make install && make test
 sudo: required

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-clover2 computer language
+# clover2 computer language
+
+[![Build Status](https://travis-ci.org/ab25cq/clover2.svg?branch=master)](https://travis-ci.org/ab25cq/clover2)
+
 
 version 3.1.8
 


### PR DESCRIPTION
よくGithubのREADMEのところに[![Build Status](https://travis-ci.org/hsk/clover2.svg?branch=master)](https://travis-ci.org/hsk/clover2)のようなアイコンが並んでいると思うのですが、Travis-CIというサイトを利用して自動テストをUbuntu上などでできるようです。これを動かしておくとUbuntuで動くことが保証できるし、それ以外の環境などで作成している場合でも対応していることが明らかにできるので信頼性も上がるようです。

.travis.yml ファイルの設定を作って、あとはgithubのサイトをtravis-ciのサイトにアクセスしてチェックするようにすると

https://travis-ci.org/hsk/clover2

のような形でチェックできるようになるので良かったら対応よろしくお願いします。